### PR TITLE
Fix readme typo/historical artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ http://physics.oregonstate.edu/~roundyd/fac
 To build fac (assuming you have just cloned fac, and do not have an
 older version of fac) just run
 
-    sh build-linux.sh
+    sh build/linux.sh
 
 This should build fac on an x86-64 linux system.  You may be able to
 use build-freebsd.sh to build on freebsd (but it is likely


### PR DESCRIPTION
It seems like the build instruction should be `build/linux.sh` instead of `build-linux.sh`