### PR TITLE
Chore: Add pre-compiled binary using GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
-name: Rust
+name: Release
 
 on:
-  workflow_dispatch:
+  push:
+    tags: [ v*.*.* ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,13 +7,49 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
+  deploy:
+    name: Deploy
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      matrix:
+        job:
+          - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: true }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , use-cross: true }
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v2
+      - name: Build target
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.job.use-cross }}
+          command: build
+          args: --release --target ${{ matrix.job.target }}
+
+      - name: Strip release binary (linux and macOS)
+        if: matrix.job.os != 'windows-latest'
+        run: |
+          if [ "${{ matrix.job.target }}" = "arm-unknown-linux-gnueabihf" ]; then
+            sudo apt-get -y install gcc-arm-linux-gnueabihf
+            arm-linux-gnueabihf-strip "target/${{ matrix.job.target }}/release/fac"
+          else
+            strip "target/${{ matrix.job.target }}/release/fac"
+          fi
+
+      - id: get_version
+        uses: battila7/get-version-action@v2
+      - name: Package
+        shell: bash
+        run: |
+          bin="target/${{ matrix.job.target }}/release/fac"
+          staging="fac-${{ steps.get_version.outputs.version }}-${{ matrix.job.target }}"
+
+          mkdir -p "$staging"/doc
+          cp COPYING README.md $bin $staging
+          cp web/*.md "$staging"/doc
+          tar czvf "$staging.tar.gz" $staging
+
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+            files: 'fac*'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,19 @@
+name: Rust
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         job:
-          - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: true }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , use-cross: true }
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hey there,

This PR allows GitHub Actions to run a build and create a tarball with documentation and a pre-compiled binary.

You can see the resulting artefact [here](https://github.com/ngirard/fac/releases/tag/v0.5.3).
The build is triggered by a new release. The tag is expected to start with `v`, which is a different convention than yours, so so might want to change that.
Also, the build failed on ARM because of some error when building `bigbro`. I didn't investigate any further.

Cheers